### PR TITLE
update rxjs to version 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/vlasovilya/rxsync#readme",
   "dependencies": {
     "lodash": "^4.17.15",
-    "rxjs": "^5.5.6"
+    "rxjs": "^6.0.0"
   }
 }


### PR DESCRIPTION
Updates rxjs to version 6.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.